### PR TITLE
Change kong_response.send to kong_response.exit for error response

### DIFF
--- a/src/access.lua
+++ b/src/access.lua
@@ -115,7 +115,7 @@ function _M.execute(conf)
       response_body = string.match(body, "%b{}")
     end
 
-    return kong_response.send(status_code, response_body)
+    return kong_response.exit(status_code, response_body)
   end
 
 end


### PR DESCRIPTION
Apparently kong.response.send is not defined, put in kong.response.exit to return response on error from "check url"
