### PR TITLE
Bug fix

### DIFF
--- a/src/access.lua
+++ b/src/access.lua
@@ -115,7 +115,7 @@ function _M.execute(conf)
       response_body = string.match(body, "%b{}")
     end
 
-    return kong_response.send(status_code, response_body)
+    return kong_response.exit(status_code, response_body)
   end
 
 end


### PR DESCRIPTION
This PR fixing the following issue: 

```
172.18.0.1 - - [21/Nov/2019:14:28:38 +0000] "GET /posts HTTP/1.1" 500 43 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36"
coroutine 0:
	/usr/local/share/lua/5.1/kong/plugins/middleman/access.lua: in function 'execute'
	/usr/local/share/lua/5.1/kong/plugins/middleman/handler.lua:14: in function </usr/local/share/lua/5.1/kong/plugins/middleman/handler.lua:12>
coroutine 1:
	[C]: in function 'resume'
	coroutine.wrap:21: in function <coroutine.wrap:21>
	/usr/local/share/lua/5.1/kong/init.lua:468: in function 'access'
	access_by_lua(nginx-kong.conf:98):2: in function <access_by_lua(nginx-kong.conf:98):1>, client: 172.18.0.1, server: kong, request: "GET /posts HTTP/1.1", host: "localhost:8000"
2019/11/21 14:28:38 [error] 31#0: *60 [lua] responses.lua:121: access(): /usr/local/share/lua/5.1/kong/plugins/middleman/access.lua:118: attempt to call field 'send' (a nil value), client: 172.18.0.1, server: kong, request: "GET /posts HTTP/1.1", host: "localhost:8000"
```